### PR TITLE
Support IE8, take 2

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     ["transform-es2015-modules-commonjs", { "loose": true }],
     "transform-es2015-block-scoping",
     "transform-es2015-function-name",
+    "transform-es3-member-expression-literals",
     "transform-es3-property-literals",
     "check-es2015-constants"
   ]

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-transform-es2015-block-scoping": "^6.7.1",
     "babel-plugin-transform-es2015-function-name": "^6.5.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.0",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
     "babel-plugin-transform-es3-property-literals": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "eslint": "^1.10.3",


### PR DESCRIPTION
I may or may not have forgotten the other transform in the last PR 😆 

``` diff
-var ReactSpinner = _react2.default.createClass({
+var ReactSpinner = _react2['default'].createClass({
   displayName: 'ReactSpinner',

   propTypes: {
-    config: _react2.default.PropTypes.object,
-    stopped: _react2.default.PropTypes.bool
+    config: _react2['default'].PropTypes.object,
+    stopped: _react2['default'].PropTypes.bool
   },

   componentDidMount: function componentDidMount() {
-    this.spinner = new _spin2.default(this.props.config);
+    this.spinner = new _spin2['default'](this.props.config);
     if (!this.props.stopped) {
       this.spinner.spin(this.refs.container);
     }
@@ -40,8 +40,8 @@ var ReactSpinner = _react2.default.createClass({
   },

   render: function render() {
-    return _react2.default.createElement('span', { ref: 'container' });
+    return _react2['default'].createElement('span', { ref: 'container' });
   }
 });

-exports.default = ReactSpinner;
\ No newline at end of file
+exports['default'] = ReactSpinner;
\ No newline at end of file
```
