### PR TITLE
Have a default export for common js as well

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["react"],
   "plugins": [
+    "add-module-exports",
     ["transform-es2015-modules-commonjs", { "loose": true }],
     "transform-es2015-block-scoping",
     "transform-es2015-function-name",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-cli": "^6.6.0",
     "babel-eslint": "^5.0.0",
     "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.1.3",
     "babel-plugin-check-es2015-constants": "^6.7.2",
     "babel-plugin-transform-es2015-block-scoping": "^6.7.1",
     "babel-plugin-transform-es2015-function-name": "^6.5.0",


### PR DESCRIPTION
Allows CommonJS users to not have to worry about `.default` interop

``` diff
-exports.default = ReactSpinner;
\ No newline at end of file
+exports.default = ReactSpinner;
+module.exports = exports['default'];
\ No newline at end of file
```
